### PR TITLE
Fix: Do not create arbitrary directory `2` when sourcing spath

### DIFF
--- a/spath.sh
+++ b/spath.sh
@@ -70,7 +70,7 @@ export TESTSUITEFLAGS=--jobs=9
 #
 # Added it back. The new tomcat 7 scripts don't require that 
 # CATALINA_HOME is set, so this is really for TC 6 compat. jhrg 12/30/14
-tc=`ls -d -1 $prefix/apache-tomcat-* 2> /dev/null | grep -v '.*\.tar\.gz' >2 /dev/null`
+tc=`ls -d -1 $prefix/apache-tomcat-* 2> /dev/null | grep -v '.*\.tar\.gz'`
 if test -n "$tc"
 then
     export TOMCAT_DIR=$tc


### PR DESCRIPTION
> Co-authored-by: ndp-opendap <ndp@opendap.org>